### PR TITLE
fix(pkg)!: The package name should be `commitlint-config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,23 @@
 ## Changelog
 
-## [1.0.1](https://github.com/logdna/commitlint-config-mezmo/compare/v1.0.0...v1.0.1) (2022-06-22)
+## [1.0.1](https://github.com/logdna/commitlint-config/compare/v1.0.0...v1.0.1) (2022-06-22)
 
 
 ### Bug Fixes
 
-* **ci**: Add triggers for approval to run forked PRs [e8e43c9](https://github.com/logdna/commitlint-config-mezmo/commit/e8e43c9e25f60aa4cf6e7d93138abd83654f7a05) - Darin Spivey, closes: [#3](https://github.com/logdna/commitlint-config-mezmo/issues/3)
+* **ci**: Add triggers for approval to run forked PRs [e8e43c9](https://github.com/logdna/commitlint-config/commit/e8e43c9e25f60aa4cf6e7d93138abd83654f7a05) - Darin Spivey, closes: [#3](https://github.com/logdna/commitlint-config/issues/3)
 
 # 1.0.0 (2022-06-22)
 
 
 ### Build System
 
-* **initial**: Project scaffolding and initial code [72e2273](https://github.com/logdna/commitlint-config-mezmo/commit/72e22738da75f0a0a661137a35ca861e9ba8cf3f) - Darin Spivey, closes: [#1](https://github.com/logdna/commitlint-config-mezmo/issues/1)
+* **initial**: Project scaffolding and initial code [72e2273](https://github.com/logdna/commitlint-config/commit/72e22738da75f0a0a661137a35ca861e9ba8cf3f) - Darin Spivey, closes: [#1](https://github.com/logdna/commitlint-config/issues/1)
 
 
 ### Miscellaneous
 
-* Initial commit [e8766e0](https://github.com/logdna/commitlint-config-mezmo/commit/e8766e083294a4b3ced9d550235648aa834ab2f1) - Darin Spivey
+* Initial commit [e8766e0](https://github.com/logdna/commitlint-config/commit/e8766e083294a4b3ced9d550235648aa834ab2f1) - Darin Spivey
 
 
 ### **BREAKING CHANGES**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 library 'magic-butler-catalogue'
 
-def PROJECT_NAME = "commitlint-config-mezmo"
+def PROJECT_NAME = "commitlint-config"
 def CURRENT_BRANCH = [env.CHANGE_BRANCH, env.BRANCH_NAME]?.find{branch -> branch != null}
 def DEFAULT_BRANCH = 'main'
 def TRIGGER_PATTERN = ".*@logdnabot.*"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-## commitlint-config-mezmo
+## commitlint-config
 
 [Commitlint][] Configuration to enforce commit message best practices on public repositories
 
 ## Installation
 
 ```bash
-$ npm install commitlint @logdna/commitlint-config-mezmo
+$ npm install commitlint @logdna/commitlint-config
 ```
 
 ## Usage
@@ -18,7 +18,7 @@ Adding a script to expose `commitlint` in the package.json `scripts`.
 Below is an example of linting all commits on the active branch that have not been merged into main
 ```json
 "commitlint": {
-  "extends": "@logdna/commitlint-config-mezmo"
+  "extends": "@logdna/commitlint-config"
 },
 "scripts": {
   "commitlint": "commitlint --from=origin/main --to=HEAD",
@@ -31,14 +31,14 @@ Below is an example of linting all commits on the active branch that have not be
 This package may additionally be installed globally as a command lint tool (`commitlint-mezmo`)
 
 ```bash
-$ npm install -g @logdna/commitlint-config-mezmo
+$ npm install -g @logdna/commitlint-config
 $ commitlint-mezmo <options>
 ```
 
 or executed immediately with `npx`
 
 ```bash
-$ npx @logdna/commitlint-config-mezmo -f origin/master
+$ npx @logdna/commitlint-config -f origin/master
 ```
 
 #### OPTIONS

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,7 +14,7 @@ const {version} = require('../package.json')
 const usage = fs.readFileSync(path.join(__dirname, './usage.txt'), 'utf8')
 
 const log = util.debuglog('lint')
-const HELP_URL = 'https://github.com/logdna/commitlint-config-mezmo'
+const HELP_URL = 'https://github.com/logdna/commitlint-config'
 const ROOT = path.join(__dirname, '..')
 const CONFIG = path.join(ROOT, 'index.js')
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@logdna/commitlint-config-mezmo",
+  "name": "@logdna/commitlint-config",
   "description": "Commitlint configuration to enforce commit message best practices",
   "version": "1.0.1",
   "main": "index.js",
@@ -26,11 +26,11 @@
   "author": "Darin Spivey <darin.spivey@mezmo.com>",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/logdna/commitlint-config-mezmo"
+    "url": "git+ssh://git@github.com/logdna/commitlint-config"
   },
-  "homepage": "https://github.com/logdna/commitlint-config-mezmo",
+  "homepage": "https://github.com/logdna/commitlint-config",
   "bugs": {
-    "url": "https://github.com/logdna/commitlint-config-mezmo/issues"
+    "url": "https://github.com/logdna/commitlint-config/issues"
   },
   "license": "SEE LICENSE IN LICENSE",
   "publishConfig": {


### PR DESCRIPTION
The package name should not contain the company name. It will
be published under our company namespace which removes the
need to hardcode the name.

Fixes: #5